### PR TITLE
Enable RPC and add Docker compose file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,5 +68,10 @@ EXPOSE 20334
 EXPOSE 20335
 EXPOSE 20336
 
+EXPOSE 30333
+EXPOSE 30334
+EXPOSE 30335
+EXPOSE 30336
+
 # On docker run, start the consensus nodes
 CMD ["/bin/bash", "/opt/run.sh"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Clone the repository and build the Docker image:
     cd neo-privatenet-docker
     ./docker_build.sh
 
-Just start the private networkL
+Just start the private network:
 
     ./docker_run.sh
 
@@ -26,6 +26,13 @@ Start the private network, create a wallet and automatically claim the initial N
 
     ./docker_run_and_create_wallet.sh
 
+_or_, if you prefer `docker-compose`, you can start the nodes with:
+
+    docker-compose up -d
+
+You can now claim the initial NEO and GAS:
+
+   ./create_wallet.sh
 
 ## Install neo-gui or neo-gui-developer
 

--- a/create_wallet.sh
+++ b/create_wallet.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+WALLET_PWD="coz"
+
+echo "Starting script to claim NEO and GAS..."
+CLAIM_CMD="python3.5 /opt/neo-python/contrib/privnet-claim-neo-and-gas.py -o /tmp/wallet -p ${WALLET_PWD} -w /tmp/wif"
+DOCKER_CMD="docker exec -it neo-privnet ${CLAIM_CMD}"
+echo $DOCKER_CMD
+echo
+($DOCKER_CMD)
+
+echo
+echo "Copying wallet file and wif key out of Docker container..."
+docker cp neo-privnet:/tmp/wif ./neo-privnet.wif
+docker cp neo-privnet:/tmp/wallet ./neo-privnet.wallet
+
+echo
+echo "--------------------"
+echo
+echo "All done! You now have 2 files in the current directory:"
+echo
+echo "  neo-privnet.wallet .. a wallet you can use with neo-python (pwd: ${WALLET_PWD})"
+echo "  neo-privnet.wif ..... a wif private key you can import into other clients"
+echo
+echo "Enjoy!"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  neo-privnet:
+    build: .
+    command: /bin/bash /opt/private_chain_start.sh /opt/
+    container_name: neo-privnet
+    ports:
+      - 10333-10336:10333-10336
+      - 20333-20336:20333-20336
+      - 30333-30336:30333-30336
+    volumes:
+      - /opt/node1/neo-cli/Chain
+      - /opt/node2/neo-cli/Chain
+      - /opt/node3/neo-cli/Chain
+      - /opt/node4/neo-cli/Chain

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3'
 services:
   neo-privnet:
     build: .
-    command: /bin/bash /opt/private_chain_start.sh /opt/
     container_name: neo-privnet
     ports:
       - 10333-10336:10333-10336

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -13,4 +13,4 @@ if [ -n "$CONTAINER" ]; then
 fi
 
 echo "Starting container..."
-docker run -d --name neo-privnet -p 20333-20336:20333-20336/tcp -h neo-privnet neo-privnet
+docker run -d --name neo-privnet -p 20333-20336:20333-20336/tcp -p 30333-30336:30333-30336/tcp -h neo-privnet neo-privnet

--- a/docker_run_and_create_wallet.sh
+++ b/docker_run_and_create_wallet.sh
@@ -16,29 +16,7 @@
 
 ./docker_run.sh
 
-WALLET_PWD="coz"
-
 echo "Waiting 10 seconds to let consensus nodes start..."
 sleep 10
 
-echo "Starting script to claim NEO and GAS..."
-CLAIM_CMD="python3.5 /opt/neo-python/contrib/privnet-claim-neo-and-gas.py -o /tmp/wallet -p ${WALLET_PWD} -w /tmp/wif"
-DOCKER_CMD="docker exec -it neo-privnet ${CLAIM_CMD}"
-echo $DOCKER_CMD
-echo
-($DOCKER_CMD)
-
-echo
-echo "Copying wallet file and wif key out of Docker container..."
-docker cp neo-privnet:/tmp/wif ./neo-privnet.wif
-docker cp neo-privnet:/tmp/wallet ./neo-privnet.wallet
-
-echo
-echo "--------------------"
-echo
-echo "All done! You now have 2 files in the current directory:"
-echo
-echo "  neo-privnet.wallet .. a wallet you can use with neo-python (pwd: ${WALLET_PWD})"
-echo "  neo-privnet.wif ..... a wif private key you can import into other clients"
-echo
-echo "Enjoy!"
+./create_wallet.sh

--- a/scripts/start_consensus_node.sh
+++ b/scripts/start_consensus_node.sh
@@ -4,7 +4,7 @@ set wallet [lindex $argv 1]
 set password [lindex $argv 2]
 set timeout -1
 cd $dnpath
-spawn dotnet neo-cli.dll
+spawn dotnet neo-cli.dll --rpc
 expect "neo>"
 send "open wallet $wallet\n"
 expect "password:"


### PR DESCRIPTION
This PR does a couple things:

First, it enables RPC mode on the nodes. This is useful because a lot of Neo tooling revolves around making API requests to the RPC nodes, e.g. broadcasting transactions!

Next, I added docker-compose.yml as an alternative to the bash scripts for starting the container. Users can just run: `docker-compose up`. Common workflows ftw.

This is useful for a few things, one is it acts as a starting point for others looking to incorporate  this into a bigger project (I've done this). and, most importantly, maybe: it adds volumes for the Chain storage, to persist the blockchain between container rebuilds.

Thirdly, i broke the `docker_run_and_create_wallet.sh` command into two parts, adding `create_wallet.sh`, so you can run just that part, for example if you're using docker-compose to start your nodes.

Thanks!