### PR TITLE
Updated Dockerfile to use specific neo-py commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ ADD ./scripts/start_consensus_node.sh /opt/
 
 # neo-python setup
 RUN git clone https://github.com/CityOfZion/neo-python.git /opt/neo-python
-RUN cd /opt/neo-python && git checkout origin/development -b development
+RUN cd /opt/neo-python && git checkout 87b5ff24f4dff5ec939032ded29226d27b3adaa0 -b dev-fixed
 RUN pip3 install -r /opt/neo-python/requirements.txt
 
 # Inform Docker what ports to expose

--- a/README.md
+++ b/README.md
@@ -32,7 +32,14 @@ _or_, if you prefer `docker-compose`, you can start the nodes with:
 
 You can now claim the initial NEO and GAS:
 
-   ./create_wallet.sh
+    ./create_wallet.sh
+
+`./create_wallet` will display several internal error messages, which is expected as long as at the end you still get a success message.
+
+---
+
+There is also a turnkey Docker image with the initial 100m NEO and 16.6k GAS already claimed in a ready-to-use wallet available here: https://hub.docker.com/r/metachris/neo-privnet-with-gas/
+
 
 ## Install neo-gui or neo-gui-developer
 


### PR DESCRIPTION
* Using neo-python 87b5ff24f4dff5ec939032ded29226d27b3adaa0 instead of
possibly broken latest development. This commit is proven to work.
* Updated README with link to image on Docker hub with 16k GAS ready

FYI the commit hash is the latest state of development on 2017-11-20