### PR TITLE
Specify neo-cli zip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 
 before_install:
-  - docker build -t neo-privnet .
+  - bash ./docker_build.sh
   - docker run -d --name neo-privnet -p 20333-20336:20333-20336/tcp -p 30333-30336:30333-30336/tcp -h neo-privnet neo-privnet
   - docker ps -a
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y dotnet-sdk-2.0.0
 # APT cleanup to reduce image size
 RUN rm -rf /var/lib/apt/lists/*
 
-COPY /opt/neo-cli.zip /opt/neo-cli.zip
+ADD ./neo-cli.zip /opt/neo-cli.zip
 
 # Extract and prepare four consensus nodes
 RUN unzip -d /opt/node1 /opt/neo-cli.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,6 @@ RUN apt-get update && apt-get install -y dotnet-sdk-2.0.0
 # APT cleanup to reduce image size
 RUN rm -rf /var/lib/apt/lists/*
 
-# Download neo-cli
-RUN wget -O /opt/neo-cli.zip https://github.com/neo-project/neo-cli/releases/download/v2.4.1/neo-cli-ubuntu.16.04-x64.zip
-
 # Extract and prepare four consensus nodes
 RUN unzip -d /opt/node1 /opt/neo-cli.zip
 RUN unzip -d /opt/node2 /opt/neo-cli.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get update && apt-get install -y dotnet-sdk-2.0.0
 # APT cleanup to reduce image size
 RUN rm -rf /var/lib/apt/lists/*
 
+COPY /opt/neo-cli.zip /opt/neo-cli.zip
+
 # Extract and prepare four consensus nodes
 RUN unzip -d /opt/node1 /opt/neo-cli.zip
 RUN unzip -d /opt/node2 /opt/neo-cli.zip

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 if [ -z "$1" ]; 
-then
-    echo "no neo-cli.zip provided - fetching default neo-cli" 
-    wget -O ./neo-cli.zip https://github.com/neo-project/neo-cli/releases/download/v2.4.1/neo-cli-ubuntu.16.04-x64.zip
+then    
+    if [ -e neo-release241.zip ]
+    then
+        echo "no neo-cli.zip provided - release already downloaded" 
+    else
+        echo "no neo-cli.zip provided - release already downloaded" 
+        wget -O ./neo-release241.zip https://github.com/neo-project/neo-cli/releases/download/v2.4.1/neo-cli-ubuntu.16.04-x64.zip
+    fi
+    cp ./neo-release241.zip ./neo-cli.zip
 else
     echo "local neo-cli.zip provided - copying" 
     cp $1 ./neo-cli.zip

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
+if [ -z "$VAR" ]; 
+    then wget -O /opt/neo-cli.zip https://github.com/neo-project/neo-cli/releases/download/v2.4.1/neo-cli-ubuntu.16.04-x64.zip
+    else cp $1 /opt/neo-cli.zip
+
 docker build -t neo-privnet .

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -5,7 +5,7 @@ then
     then
         echo "no neo-cli.zip provided - release already downloaded" 
     else
-        echo "no neo-cli.zip provided - release already downloaded" 
+        echo "no neo-cli.zip provided - downloading now" 
         wget -O ./neo-release241.zip https://github.com/neo-project/neo-cli/releases/download/v2.4.1/neo-cli-ubuntu.16.04-x64.zip
     fi
     cp ./neo-release241.zip ./neo-cli.zip

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -2,10 +2,10 @@
 if [ -z "$1" ]; 
 then
     echo "no neo-cli.zip provided - fetching default neo-cli" 
-    wget -O /opt/neo-cli.zip https://github.com/neo-project/neo-cli/releases/download/v2.4.1/neo-cli-ubuntu.16.04-x64.zip
+    wget -O ./neo-cli.zip https://github.com/neo-project/neo-cli/releases/download/v2.4.1/neo-cli-ubuntu.16.04-x64.zip
 else
     echo "local neo-cli.zip provided - copying" 
-    cp $1 /opt/neo-cli.zip
+    cp $1 ./neo-cli.zip
 fi
 
 docker build -t neo-privnet .

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -z "$VAR" ]; 
+if [ -z "$1" ]; 
     then wget -O /opt/neo-cli.zip https://github.com/neo-project/neo-cli/releases/download/v2.4.1/neo-cli-ubuntu.16.04-x64.zip
     else cp $1 /opt/neo-cli.zip
 fi

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 if [ -z "$1" ]; 
-    then wget -O /opt/neo-cli.zip https://github.com/neo-project/neo-cli/releases/download/v2.4.1/neo-cli-ubuntu.16.04-x64.zip
-    else cp $1 /opt/neo-cli.zip
+then
+    echo "no neo-cli.zip provided - fetching default neo-cli" 
+    wget -O /opt/neo-cli.zip https://github.com/neo-project/neo-cli/releases/download/v2.4.1/neo-cli-ubuntu.16.04-x64.zip
+else
+    echo "local neo-cli.zip provided - copying" 
+    cp $1 /opt/neo-cli.zip
 fi
 
 docker build -t neo-privnet .

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -2,5 +2,6 @@
 if [ -z "$VAR" ]; 
     then wget -O /opt/neo-cli.zip https://github.com/neo-project/neo-cli/releases/download/v2.4.1/neo-cli-ubuntu.16.04-x64.zip
     else cp $1 /opt/neo-cli.zip
+fi
 
 docker build -t neo-privnet .


### PR DESCRIPTION
This change optionally allows the docker build process to be provided with a zip of neo-cli, rather than always fetching the official release version.