### PR TITLE
docker_build.sh args: --no-cache and --neo-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM microsoft/dotnet:2.0-runtime
 LABEL maintainer="City of Zion"
-LABEL authors="hal0x2328, phetter, metachris, ashant"
+LABEL authors="metachris, ashant, hal0x2328, phetter"
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ Clone the repository and build the Docker image:
     cd neo-privatenet-docker
     ./docker_build.sh
 
-Just start the private network:
+`docker_build.sh` has a few possible arguments:
+
+* Disable Docker image caching with `docker_build.sh --no-cache`
+* Use a custom neo-cli zip file `docker_build.sh --neo-cli <zip-fn>`
+* Show the help with `docker_build.sh -h`
+
+After the image is built, you can start the private network like this:
 
     ./docker_run.sh
 

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -4,15 +4,45 @@ set -e
 # To use a newer neo-cli version, just update this variable:
 NEO_CLI_VERSION="2.7.1"
 
+function usage {
+    echo "Usage: $0 [--no-cache] [--neo-cli <zip-fn>]"
+}
+
+while [[ "$#" > 0 ]]; do case $1 in
+    -h)
+        usage
+        exit 0
+        ;;
+    --no-cache)
+        DISABLE_CACHE=1
+        shift
+        ;;
+    --neo-cli)
+        # Custom neo-cli zip filename
+        NEO_CLI_CUSTOM_ZIPFN=$2
+        if [[ -z $NEO_CLI_CUSTOM_ZIPFN ]]; then
+            echo "Error: Please specify a neo-cli zip file"
+            usage
+            exit 1
+        fi
+        echo "Custom neo-cli zip: $NEO_CLI_CUSTOM_ZIPFN"
+        shift; shift
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+  esac;
+done
+
 # Definition of standard neo-cli filenames and URL based on the version
 NEO_CLI_ZIPFN="neo-release-${NEO_CLI_VERSION}.zip"
 NEO_CLI_URL="https://github.com/neo-project/neo-cli/releases/download/v${NEO_CLI_VERSION}/neo-cli-ubuntu.16.04-x64.zip"
 
-if [ -z "$1" ];
-then
-    echo "Using default neo-cli v${NEO_CLI_VERSION}"
+if [ -z "$NEO_CLI_CUSTOM_ZIPFN" ]; then
+    echo "Using downloaded neo-cli v${NEO_CLI_VERSION}"
 
-    if [ -e "${NEO_CLI_ZIPFN}" ]
+    if [ -e "${NEO_CLI_ZIPFN}" ] && [ -z "$DISABLE_CACHE" ]
     then
         echo "- release already downloaded: ${NEO_CLI_ZIPFN}"
     else
@@ -21,8 +51,13 @@ then
     fi
     cp $NEO_CLI_ZIPFN ./neo-cli.zip
 else
-    echo "Using custom neo-cli.zip: $1"
-    cp $1 ./neo-cli.zip
+    echo "Using custom neo-cli.zip: $NEO_CLI_CUSTOM_ZIPFN"
+    cp $NEO_CLI_CUSTOM_ZIPFN ./neo-cli.zip
 fi
 
-docker build -t neo-privnet .
+if [ -z "$DISABLE_CACHE" ]; then
+  docker build -t neo-privnet .
+else
+  echo "docker build no cache"
+  docker build --no-cache -t neo-privnet .
+fi


### PR DESCRIPTION
Added `--no-cache` argument to `docker_build.sh` which disables caching for the Docker build process, and also for the file download.

Also added `--neo-cli <fn>` argument, and help output for all unknown arguments.