### PR TITLE
Update consensus to 2.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN pip3 install -e .
 
 # Add the neo-cli package
 ADD ./neo-cli.zip /opt/neo-cli.zip
+ADD ./SimplePolicy.zip /opt/SimplePolicy.zip
 
 # Extract and prepare four consensus nodes
 RUN unzip -q -d /opt/node1 /opt/neo-cli.zip
@@ -49,8 +50,15 @@ RUN unzip -q -d /opt/node2 /opt/neo-cli.zip
 RUN unzip -q -d /opt/node3 /opt/neo-cli.zip
 RUN unzip -q -d /opt/node4 /opt/neo-cli.zip
 
+# Extract and prepare SimplePolicy plugin
+RUN unzip -q -d /opt/node1/neo-cli /opt/SimplePolicy.zip
+RUN unzip -q -d /opt/node2/neo-cli /opt/SimplePolicy.zip
+RUN unzip -q -d /opt/node3/neo-cli /opt/SimplePolicy.zip
+RUN unzip -q -d /opt/node4/neo-cli /opt/SimplePolicy.zip
+
 # Remove zip neo-cli package
 RUN rm /opt/neo-cli.zip
+RUN rm /opt/SimplePolicy.zip
 
 # Add config files
 ADD ./configs/config1.json /opt/node1/neo-cli/config.json

--- a/configs/config-windows.json
+++ b/configs/config-windows.json
@@ -2,6 +2,7 @@
   "ApplicationConfiguration": {
     "Paths": {
       "Chain": "Chain",
+      "Index": "Index",
       "Notifications": "Notifications"
     },
     "P2P": {

--- a/configs/config-windows.json
+++ b/configs/config-windows.json
@@ -10,6 +10,7 @@
       "WsPort": 10333
     },
     "RPC": {
+      "BindAddress": "0.0.0.0",
       "Port": 30333,
       "SslCert": "",
       "SslCertPassword": ""

--- a/configs/config1.json
+++ b/configs/config1.json
@@ -10,6 +10,7 @@
             "WsPort": 10333
         },
         "RPC": {
+            "BindAddress": "0.0.0.0",
             "Port": 30333,
             "SslCert": "",
             "SslCertPassword": ""

--- a/configs/config1.json
+++ b/configs/config1.json
@@ -2,6 +2,7 @@
     "ApplicationConfiguration": {
         "Paths": {
             "Chain": "Chain_{0}",
+            "Index": "Index_{0}",
             "ApplicationLogs": "ApplicationLogs_{0}"
         },
         "P2P": {
@@ -14,10 +15,10 @@
             "SslCertPassword": ""
         },
         "UnlockWallet": {
-            "Path": "",
-            "Password": "",
-            "StartConsensus": false,
-            "IsActive": false
+            "Path": "wallet1.json",
+            "Password": "one",
+            "StartConsensus": true,
+            "IsActive": true
         }
     }
 }

--- a/configs/config2.json
+++ b/configs/config2.json
@@ -2,6 +2,7 @@
     "ApplicationConfiguration": {
         "Paths": {
             "Chain": "Chain_{0}",
+            "Index": "Index_{0}",
             "ApplicationLogs": "ApplicationLogs_{0}"
         },
         "P2P": {
@@ -14,10 +15,10 @@
             "SslCertPassword": ""
         },
         "UnlockWallet": {
-            "Path": "",
-            "Password": "",
-            "StartConsensus": false,
-            "IsActive": false
+            "Path": "wallet2.json",
+            "Password": "two",
+            "StartConsensus": true,
+            "IsActive": true
         }
     }
 }

--- a/configs/config2.json
+++ b/configs/config2.json
@@ -10,6 +10,7 @@
             "WsPort": 10334
         },
         "RPC": {
+            "BindAddress": "0.0.0.0",
             "Port": 30334,
             "SslCert": "",
             "SslCertPassword": ""

--- a/configs/config3.json
+++ b/configs/config3.json
@@ -2,6 +2,7 @@
     "ApplicationConfiguration": {
         "Paths": {
             "Chain": "Chain_{0}",
+            "Index": "Index_{0}",
             "ApplicationLogs": "ApplicationLogs_{0}"
         },
         "P2P": {
@@ -14,10 +15,10 @@
             "SslCertPassword": ""
         },
         "UnlockWallet": {
-            "Path": "",
-            "Password": "",
-            "StartConsensus": false,
-            "IsActive": false
+            "Path": "wallet3.json",
+            "Password": "three",
+            "StartConsensus": true,
+            "IsActive": true
         }
     }
 }

--- a/configs/config3.json
+++ b/configs/config3.json
@@ -10,6 +10,7 @@
             "WsPort": 10335
         },
         "RPC": {
+            "BindAddress": "0.0.0.0",
             "Port": 30335,
             "SslCert": "",
             "SslCertPassword": ""

--- a/configs/config4.json
+++ b/configs/config4.json
@@ -2,6 +2,7 @@
     "ApplicationConfiguration": {
         "Paths": {
             "Chain": "Chain_{0}",
+            "Index": "Index_{0}",
             "ApplicationLogs": "ApplicationLogs_{0}"
         },
         "P2P": {
@@ -14,10 +15,10 @@
             "SslCertPassword": ""
         },
         "UnlockWallet": {
-            "Path": "",
-            "Password": "",
-            "StartConsensus": false,
-            "IsActive": false
+            "Path": "wallet4.json",
+            "Password": "four",
+            "StartConsensus": true,
+            "IsActive": true
         }
     }
 }

--- a/configs/config4.json
+++ b/configs/config4.json
@@ -10,6 +10,7 @@
             "WsPort": 10336
         },
         "RPC": {
+            "BindAddress": "0.0.0.0",
             "Port": 30336,
             "SslCert": "",
             "SslCertPassword": ""

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -40,7 +40,7 @@ done
 NEO_CLI_ZIPFN="neo-release-${NEO_CLI_VERSION}.zip"
 NEO_CLI_URL="https://github.com/neo-project/neo-cli/releases/download/v${NEO_CLI_VERSION}/neo-cli-linux-x64.zip"
 NEO_PLUGIN_ZIPFN="SimplePolicy.zip"
-NEO_PLUGIN_URL="https://github.com/neo-project/neo-plugins/releases/download/v${NEO_CLI_VERSION}/SimplePolicy.zip"
+NEO_PLUGIN_URL="https://github.com/neo-project/neo-plugins/releases/download/v${NEO_PLUGINS_VERSION}/SimplePolicy.zip"
 
 if [ -z "$NEO_CLI_CUSTOM_ZIPFN" ]; then
     echo "Using downloaded neo-cli v${NEO_CLI_VERSION}"

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -2,7 +2,8 @@
 set -e
 
 # To use a newer neo-cli version, just update this variable:
-NEO_CLI_VERSION="2.8.0"
+NEO_CLI_VERSION="2.9.0"
+NEO_PLUGINS_VERSION="2.9.0"
 
 function usage {
     echo "Usage: $0 [--no-cache] [--neo-cli <zip-fn>]"
@@ -38,6 +39,8 @@ done
 # Definition of standard neo-cli filenames and URL based on the version
 NEO_CLI_ZIPFN="neo-release-${NEO_CLI_VERSION}.zip"
 NEO_CLI_URL="https://github.com/neo-project/neo-cli/releases/download/v${NEO_CLI_VERSION}/neo-cli-linux-x64.zip"
+NEO_PLUGIN_ZIPFN="SimplePolicy.zip"
+NEO_PLUGIN_URL="https://github.com/neo-project/neo-plugins/releases/download/v${NEO_CLI_VERSION}/SimplePolicy.zip"
 
 if [ -z "$NEO_CLI_CUSTOM_ZIPFN" ]; then
     echo "Using downloaded neo-cli v${NEO_CLI_VERSION}"
@@ -48,6 +51,7 @@ if [ -z "$NEO_CLI_CUSTOM_ZIPFN" ]; then
     else
         echo "- downloading ${NEO_CLI_URL}..."
         wget --no-check-certificate -O $NEO_CLI_ZIPFN $NEO_CLI_URL || (rm -f $NEO_CLI_ZIPFN && exit 1)
+        wget --no-check-certificate -O $NEO_PLUGIN_ZIPFN $NEO_PLUGIN_URL || (rm -f $NEO_PLUGIN_ZIPFN && exit 1)
     fi
     cp $NEO_CLI_ZIPFN ./neo-cli.zip
 else

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -2,7 +2,7 @@
 set -e
 
 # To use a newer neo-cli version, just update this variable:
-NEO_CLI_VERSION="2.9.0"
+NEO_CLI_VERSION="2.9.1"
 NEO_PLUGINS_VERSION="2.9.0"
 
 function usage {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,10 +3,10 @@
 # This script starts four consensus and waits forever
 #
 
-screen -dmS node1 expect /opt/start_consensus_node.sh /opt/node1/neo-cli/ wallet1.json one
-screen -dmS node2 expect /opt/start_consensus_node.sh /opt/node2/neo-cli/ wallet2.json two
-screen -dmS node3 expect /opt/start_consensus_node.sh /opt/node3/neo-cli/ wallet3.json three
-screen -dmS node4 expect /opt/start_consensus_node.sh /opt/node4/neo-cli/ wallet4.json four
+screen -dmS node1 expect /opt/start_consensus_node.sh /opt/node1/neo-cli/
+screen -dmS node2 expect /opt/start_consensus_node.sh /opt/node2/neo-cli/
+screen -dmS node3 expect /opt/start_consensus_node.sh /opt/node3/neo-cli/
+screen -dmS node4 expect /opt/start_consensus_node.sh /opt/node4/neo-cli/
 
 sleep infinity
 

--- a/scripts/start_consensus_node.sh
+++ b/scripts/start_consensus_node.sh
@@ -1,16 +1,7 @@
 #!/usr/bin/expect -f
 set dnpath [lindex $argv 0]
-set wallet [lindex $argv 1]
-set password [lindex $argv 2]
 set timeout -1
 cd $dnpath
 spawn dotnet neo-cli.dll --rpc
 expect "neo>"
-send "open wallet $wallet\n"
-expect "password:"
-send "$password\n"
-expect "neo>"
-send "start consensus\n"
-expect "OnStart"
-#expect "LIVEFOREVER"
 interact


### PR DESCRIPTION
As Neo 2.9.1 will be deployed in the mainnet consensus nodes next week is a good time to start moving `neo-privatenet-docker` to this version.
This is a working private network running 2.9.1 in consensus.

Please help me test it before merge.