### PR TITLE
Fix #64 - replace ImportMultiSigContractAddr

### DIFF
--- a/scripts/claim_neo_and_gas_fixedwallet.py
+++ b/scripts/claim_neo_and_gas_fixedwallet.py
@@ -256,9 +256,12 @@ class PrivnetClaimall(object):
             wallet.CreateKey(prikey)
 
             print("Importing multi-sig contract to {}".format(walletpath))
-            multisig_args = [pkey, '3']
-            multisig_args.extend(list(nodekeys.keys()))
-            ImportMultiSigContractAddr(wallet, multisig_args)
+            
+            keys = list(nodekeys.keys()))
+            if keys[1]:
+                pubkey_script_hash = Crypto.ToScriptHash(pkey, unhex=True)	
+                verification_contract = Contract.CreateMultiSigContract(pubkey_script_hash, 3, keys)	
+                wallet.AddContract(verification_contract)
 
             dbloop = task.LoopingCall(wallet.ProcessBlocks)
             dbloop.start(1)

--- a/scripts/claim_neo_and_gas_fixedwallet.py
+++ b/scripts/claim_neo_and_gas_fixedwallet.py
@@ -259,7 +259,7 @@ class PrivnetClaimall(object):
             
             keys = list(nodekeys.keys())
             if keys[1]:
-                pubkey_script_hash = Crypto.ToScriptHash(pkey, unhex=True)	
+                pubkey_script_hash = wallet.ToScriptHash(pkey)	
                 verification_contract = Contract.CreateMultiSigContract(pubkey_script_hash, 3, keys)	
                 wallet.AddContract(verification_contract)
 

--- a/scripts/claim_neo_and_gas_fixedwallet.py
+++ b/scripts/claim_neo_and_gas_fixedwallet.py
@@ -257,7 +257,7 @@ class PrivnetClaimall(object):
 
             print("Importing multi-sig contract to {}".format(walletpath))
             
-            keys = list(nodekeys.keys()))
+            keys = list(nodekeys.keys())
             if keys[1]:
                 pubkey_script_hash = Crypto.ToScriptHash(pkey, unhex=True)	
                 verification_contract = Contract.CreateMultiSigContract(pubkey_script_hash, 3, keys)	


### PR DESCRIPTION
Fix for #64

*I did not test it.*
I replaced the call to `ImportMultiSigContractAddr` by the main lines of its implementation.

The if can be removed if `keys` always has more than 1 element which I think is true based on "Signing new transaction with 3 of 4 node keys...".